### PR TITLE
Lint all markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,30 @@
 
 For development
 
-    npm run develop
-    
+```sh
+npm run develop
+```
+
 To build and serve the production version
-    
-    npm run build
-    npm run serve
-    
+
+```
+npm run build
+npm run serve
+```
+
 To test the production version
 
-    firebase serve
+```
+firebase serve
+```
 
 To deploy the production version
 
-    firebase deploy
-
+```
+firebase deploy
+```
 
 ## Credits
 
-Thanks to [gatsbyjs](https://github.com/gatsbyjs) and the contributors of the example for [using-remark](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-remark).
+Thanks to [gatsbyjs](https://github.com/gatsbyjs) and the contributors of the
+example for [using-remark](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-remark).

--- a/src/pages/scad/01-masteringcloud.md
+++ b/src/pages/scad/01-masteringcloud.md
@@ -5,7 +5,7 @@ date: "2020-01-04"
 draft: false
 author: Simon Anliker
 tags:
-  - scad
+- "scad"
 ---
 
 # Mastering Cloud
@@ -13,83 +13,93 @@ tags:
 ## Computing Paradigms
 
 Computing paradigms (___ Computing)
+
 - Distributed
-    - Client-Server
-    - Federated
-    - Decentralised
-    - Disconnected
+  - Client-Server
+  - Federated
+  - Decentralised
+  - Disconnected
 - Service
-- Cloud 
+- Cloud
 - Utility
 - Serverless
 
 Application-level paradigms
+
 - Cloud-native
 - Serverless
-
 
 ## Services
 
 Technical characteristics
+
 - Visibility: Well-defined, unified description (declarative, interactive)
-- Interaction: Well-defined, unified interface/protocol  (message exchange patterns, layer)
-- Effect: Invocation semantics (idempotent, reversible on system, irreversible in real-world)
+- Interaction: Well-defined, unified interface/protocol (message exchange patterns,
+  layer)
+- Effect: Invocation semantics (idempotent, reversible on system, irreversible in
+  real-world)
 - Encapsulation: Encapsulate software and resources for re-use
 - Interoperability: Loose coupling (late/dynamic binding)
 
 Lifecycle characteristics
+
 - Find (search, rank, select)
 - Bind (signup, subscribe, pay, use)
 
 ```
-    Service    
-    ├── private
-    ├── public
-    │   ├── non-profit
-    │   ├── commercial
-    │   │   ├── single-user
-    │   │   │   ├── standardised
-    │   │   │   ├── proprietary
-    │   │   ├── multi-user
+Service
+├── private
+├── public
+│   ├── non-profit
+│   ├── commercial
+│   │   ├── single-user
+│   │   │   ├── standardised
+│   │   │   ├── proprietary
+│   │   ├── multi-user
 ```
-
 
 ### Ecosystem
 
 Service-oriented architecture
+
 - Service orchestration or choreography
 - Services, clients, brokers, marketplaces, messaging systems
 - Service platforms, development tools
 
 Web services (HTTP)
+
 - RESTful, resource-centric (CRUD)
 - SOAP, operation-centric (POST)
 
 Content types and schemas
+
 - Structured (JSON, YAML, XML)
 - Plain text
 - Binary documents
 - Streams
 
 Cloud services
+
 - On-demand
 - Pay-per-use
 - Elasticity
 - Robustness
 
 Microservices
+
 - Lightweight (e.g. single-function)
 - Tangible & portable implementation
 
 Scale
+
 - Y-Axis: Scale by using microservices (functional decomposition)
 - X-Axis: Scale by cloning services (horizontal duplication)
 - Z-Axis: Scale by sharding databases (data partitioning)
 
-
 ## Cloud-native & Server-less
 
 Cloud-Native Computing: Computing paradigm optimised for modern distibuted systems
+
 - ultra-scaling
 - self-healing
 - multi-tenant
@@ -103,10 +113,7 @@ Cloud-Native Computing: Computing paradigm optimised for modern distibuted syste
 - abstracted
 - adaptive
 
-
 ### FaaS
 
 - running functions in the cloud
 - real pay-per-use
-
-

--- a/src/pages/scad/02-serverless.md
+++ b/src/pages/scad/02-serverless.md
@@ -5,41 +5,46 @@ date: "2020-01-04"
 draft: false
 author: Simon Anliker
 tags:
-  - scad
+- scad
 ---
 
 # Serverless Applications
 
-# FaaS
+## FaaS
 
 - Inspired by functional programming
-- Stateless 
+- Stateless
 - Short-lived
 - Single-function(ality) microservices
 - Implied pricing model: memory + per-invocation
 
 Programming model
+
 - Heterogenous functions with specific signature (params, return values)
 - order of invocation can expressed by workflows
 
 Deployment model
+
 - upload source or compiled binaries
 - configure entry point, memory, limits
 
 Execution model
+
 - time and space limits
 - local state limits (by time or no state at all)
 - pay-per-use microbilling
-- highly parallel autoscaled exeuction 
+- highly parallel autoscaled exeuction
 
 Pricing
+
 - Determined by provider
-- Determined by application through service descriptions or annotations (emerging topic)
+- Determined by application through service descriptions or annotations (emerging
+  topic)
 
-
-## Service model
+### Service model
 
 Control plane
+
 - Deployment
 - Configuration
 - Authorisation
@@ -47,64 +52,63 @@ Control plane
 - Billing
 
 Computing plane
+
 - Platform
 - Compute
 - Storage
 - Network
 
-
-## Execution
+### Execution
 
 Event -> trigger -> rules -> actions -> results
 
 Events
+
 - Monitoring event
 - Sensor data
 - Log entry
 - ...
 
 Triggers
+
 - HTTP
 - XMPP
 - AMQP
 
 Rules: e.g. max 1 per hour
-
 Actions: Function invocation
-
 Result: e.g. JSON return value
 
-
-## Cloud Functions
+### Cloud Functions
 
 Structure
+
 - fixed or registered name
 - parameter or via context
 - single return value
 
 Language
+
 - in theory any
-- in practice dominance of Node nad Python
+- in practice dominance of Node and Python
 
 Configuration
+
 - Runtime language, entry file
 - Runtime parameters, memory, max duration, env variables
-
 
 12factor alignment: declarative setup, config in environment, backing services
 for state handling, disposability / fast startup & graceful shutdown
 
-
 ### System view
 
-* Function: Developer-supplied code (app bundle)
-* Function Encapsulation: Provider-supplied container image (runtime, libs)
-* Function Execution: Provider-supplied infrastructure (hidden specs)
-
+- Function: Developer-supplied code (app bundle)
+- Function Encapsulation: Provider-supplied container image (runtime, libs)
+- Function Execution: Provider-supplied infrastructure (hidden specs)
 
 ### Configuration
 
-* runtime environment (from list)
-* memory 128-512 MB; default 256
-* timeout 0.1-300 s; default 60
-* authoring: template or blank document
+- runtime environment (from list)
+- memory 128-512 MB; default 256
+- timeout 0.1-300 s; default 60
+- authoring: template or blank document

--- a/src/pages/scad/03-serverlessdevelopment.md
+++ b/src/pages/scad/03-serverlessdevelopment.md
@@ -5,7 +5,7 @@ date: "2020-01-04"
 draft: false
 author: Simon Anliker
 tags:
-  - scad
+- scad
 ---
 
 # Serverless Development
@@ -23,99 +23,107 @@ tags:
 - Podilizer, Termite (FaaSification of Java)
 - Lambada (FaaSification of Python)
 
-
 ## Overlays
 
 ## PyWren
 
 No explicit deployment prior to execution, deploy while executing
 
-    def my_fun(b):
-        ...
-        
-    pwex = pywren.default_executor()
-    res = pwex.map(my_fun, params)
-    
+```python
+def my_fun(b):
+    ...
+
+pwex = pywren.default_executor()
+res = pwex.map(my_fun, params)
+```
+
 ## Gee's Lambada
 
-Deployment with dependencies (requirements.txt references Lambada framework)
+Deployment with dependencies (`requirements.txt` references Lambada framework)
 
-    def my_fun(b):
-        ...
-        
-    tune = Lambada(role=..., region=..., memoery=128)
-    
-    @tune.dancer
-    def my_fun_lambda(e, c):
-        my_fun(e['stddev'])
-        
+```python
+def my_fun(b):
+    ...
+
+tune = Lambada(role=..., region=..., memoery=128)
+
+@tune.dancer
+def my_fun_lambda(e, c):
+    my_fun(e['stddev'])
+```
 
 ## FaaSification
 
-Process of automated decomposition of software into a set of function-level services: code analysis + transformation + deployment + on-demand activation
+Process of automated decomposition of software into a set of function-level
+services: code analysis + transformation + deployment + on-demand activation
 
 ### Transformation rules
 
 Entry points: no transformation of main function
 
 Function definitions:
+
 - Adapt to conventions: parameters, return value
 - Scan recursively for function calls
 - Export as function unit including dependencies
 
 Function calls:
+
 - if internal, rewire
 - if I/O, replace
 - otherwise, leave as is
 
 Monads:
+
 - Functional programming with side effects / side channels
 
-
 Open research problems
+
 - clustering
 - code inspection (deep FaaSification)
 
 ## Deployment
 
-* Implicit: web IDE
-* Explicit: provider tools
+- Implicit: web IDE
+- Explicit: provider tools
 
 Provider specific
+
 - Authorisation (e.g. function calling another function)
 - Packaging
-
 
 ### Abstraction
 
 Abstraction approach: Serverless FW
 
-    serverless create --template spotinst-nodejs --path P
-    
-    serverless config credentials --provider sptinst --token T --account A
-    
-    serverless deploy function -f hello
-    serverless invoke -f hello
-    
+```sh
+serverless create --template spotinst-nodejs --path P
+
+serverless config credentials --provider sptinst --token T --account A
+
+serverless deploy function -f hello
+serverless invoke -f hello
+```
+
 serverless.yml:
 
-    service: hello
-    provider:
-        name: spotinst
-        spotinst:
-            environment:...
-    plugins:
-        - serverless-spotinst-functions
-        
-    functions:
-        hello:
-            handler: index.main
-            runtime: nodejs8
-            memory: 128
-            timeout: 20
-            access: public
+```yaml
+service: hello
+provider:
+    name: spotinst
+    spotinst:
+        environment:...
+plugins:
+    - serverless-spotinst-functions
 
-
+functions:
+    hello:
+        handler: index.main
+        runtime: nodejs8
+        memory: 128
+        timeout: 20
+        access: public
+```
 
 ### Prototyping
 
@@ -123,44 +131,51 @@ Prototyping approach: Localstack
 
 Emulation of commercial FaaS offerings and includion into CI
 
-    localstack start [--docker]
-    
-    alias aws="aws --endpoint-url=http://localhost:4574"
-    aws lambda list-functions ...
+```sh
+localstack start [--docker]
 
+alias aws="aws --endpoint-url=http://localhost:4574"
+aws lambda list-functions ...
+```
 
 ## Debugging
 
 Problems
+
 - Crash
 - Missing dependency
 - Slowness
-. Undeterministic behaviour
+- Undeterministic behaviour
 
 Tools
+
 - Insight
 - Visualisation
 - Debugging/Profiling tools (wskdebug for OpenWhisk)
-- Feedback 
+- Feedback
 - Autotuning
 
 K-rules: Analyse -> Plan -> Execute -> Monitor
 
 Analyse
+
 - Stacktraces
 - Profiles
 - Anomalies over time
 
 Plan
+
 - Recombination of function clusters
 - Memory reconfiguration
 
 Execute
+
 - Hot deployment
 - Canary testing
 - Step/Breakpoint execution
 
 Monitor
+
 - Invocation counts
 - Invocation time
 - Throttling
@@ -168,16 +183,6 @@ Monitor
 - Variables
 
 Feeds into:
+
 - FaaS Debugging, Profiling and Autotuning Catalogue
 - Management functions
-
-
-
-
-
-
-
-
-
-
-

--- a/src/pages/scad/04-serverless-workflows.md
+++ b/src/pages/scad/04-serverless-workflows.md
@@ -5,7 +5,7 @@ date: "2020-01-04"
 draft: false
 author: Simon Anliker
 tags:
-  - scad
+- scad
 ---
 
 # Serverless Workflows
@@ -16,6 +16,7 @@ tags:
 - Connection of two or more steps
 
 Connection patterns
+
 - Sequence / chain
 - Parallelism
 - Conditions
@@ -23,21 +24,23 @@ Connection patterns
 - Complex state machine
 
 Description language
+
 - BPMN
 - BPEL
 
 Primitives (explicit)
+
 - ordering
 - control flow
 - selectors
 - data transformation
 
 Features (implicit)
+
 - DAGs (validation, optimisation, visualisation, editing)
 - checkpointing
 - monitoring, notification
 - connectors, integration
-
 
 ### Models
 
@@ -47,19 +50,19 @@ Queue model: Engine -> Queue -> Worker Cloud Functions -> Storage
 
 Direct executor model: Engine -> Worker Cloud Functions -> Storage
 
-Bridge model: Engine -> Queue -> Worker VMs + Bridge to Worker Cloud Functions -> Storage
+Bridge model: Engine -> Queue -> Worker VMs + Bridge to Worker Cloud Functions
+-> Storage
 
 Decentralized model: Cloud Functions -> Storage
 
-
 ## Systems and languages
 
-- devlarative vs imperative
+- declarative vs imperative
 - JSON vs YAML vs JavaScript
-- indetification of functions
+- identification of functions
 - handling of errors, I/O
 
-|Metrics|Amazon Step Functions|IBM Composer|Azure Druable Functions|
+|Metrics|Amazon Step Functions|IBM Composer|Azure Durable Functions|
 |:---|:---|:---|:---|
 |ST-safe (composition as functions)|No|Yes|Yes|
 |Programming model|DSL(JSON)|Composition library (JS)|async/await (C#)|
@@ -74,34 +77,26 @@ Decentralized model: Cloud Functions -> Storage
 - User (workflow author) optimisation: Code
 - System (workflow engine) optimisation: Processing
 
-Workflow preparation/rewriting: Archieve series-parallel structure for polynomial execution time from directed asyclic graphs
+Workflow preparation/rewriting: Achieve series-parallel structure for polynomial
+execution time from directed acyclic graphs
 
 Function execution
-- Resource re-use 
-    - Keep function alive (full function reuse) vs spawn new functions (full isolation)
-    - Long keep-alive -> more warm executions / short keep-alives -> less idle resources
-- Runtime pooling
-    - large pool / handle high concurrency -> increases resource overhead / better performance
-    - minial pool / fast pool exhaustion -> minimize pool; less idle resources / minimize cost
 
+- Resource re-use
+  - Keep function alive (full function reuse) vs spawn new functions (full isolation)
+  - Long keep-alive -> more warm executions / short keep-alives -> less idle resources
+- Runtime pooling
+  - large pool / handle high concurrency -> increases resource overhead /
+    better performance
+  - minimal pool / fast pool exhaustion -> minimize pool; less idle resources /
+    minimize cost
 
 Workflow execution-specific
+
 - Prefetching: Fetch function source upfront
-    - Higher latency -> less storage cost
-    - Lower latency -> more storage cost
+  - Higher latency -> less storage cost
+  - Lower latency -> more storage cost
 - Prewarming: Predictive function execution (via runtime analysis and function stats)
-    - Optimistic prewarning / low treshold -> more performance
-    - Pessimistic prewarning / high threshold -> less cost
-    - Other domains: CPU branch predictor, proactive autoscalers, predictive caches
-
-
-
-
-
-
-
-
-
-
-
-
+  - Optimistic prewarning / low treshold -> more performance
+  - Pessimistic prewarning / high threshold -> less cost
+  - Other domains: CPU branch predictor, proactive autoscalers, predictive caches

--- a/src/pages/scad/05-serverless-patterns.md
+++ b/src/pages/scad/05-serverless-patterns.md
@@ -5,7 +5,7 @@ date: "2020-01-04"
 draft: false
 author: Simon Anliker
 tags:
-  - scad
+- scad
 ---
 
 # Serverless Patterns
@@ -23,27 +23,33 @@ Serverless patterns: less mature on average
 ### Basic patterns
 
 Periodic invocation
+
 - scheduler, cron-equivalent
 - for continuous compliance at a cost
 
 Event-driven
+
 - reactive
 - const minimisation with risk to miss events
 
 Data transformation
+
 - ETL-/shell-equivalent
 - modularity for data augmentation
 
 Data streaming
+
 - load balancer-equivalent
 - data partitioning (split)
 - data aggregation (join)
 
 State machine
+
 - workflow-equivalent
 - reduced data loss risk by restarts + try/except
 
 Bundled
+
 - combination of any patterns
 
 ### Composition patterns
@@ -51,43 +57,54 @@ Bundled
 Implemented only as client-side scheduling, not composable
 
 ECA
+
 - event-condition-action
 - take next step depending on condition
 
 Forward
+
 - monad-style forwarding of data
 
 Retry
+
 - in conjunction with eventual consistency
 
 ## Antipatterns
 
 Async calls (or rather sync?)
+
 - Cost when A is running while waiting for B
 - What if B does not reply
 - Solution: use timeouts or queues
 
 Functions calling functions
+
 - Complex debugging, loose isolation, double cost
-- Solution: merge function, if not possible push data to store or queue which in turn triggers a function
+- Solution: merge function, if not possible push data to store or queue which in
+  turn triggers a function
 
 Shared code
+
 - maintenance issue, still monolithic
 - risk to hit image size limit
 - warm-up time takes longe with bigger image
 - Solution: write independent, decoupled functions
 
 Shared libs as functions
+
 - functions should do only one thing/have one purpose
 - Solutions: avoid horizontal decomposition (e.g. DB connection functions)
 
 Too many libs
+
 - image size grows
 
 Too many technologies
+
 - maintenance (requires skills)
 
 Too many functions
+
 - maintenance, complexity
 
 Distributed monolith
@@ -95,18 +112,14 @@ Distributed monolith
 ## Pitfalls
 
 Serverless trilemma (choose 2):
+
 - Blackbox: Functions should be considered as black boxes
 - Substitution: Compositions should obey a substitution principle
 - Double-billing: Invocations should not be double-billed
 
 Composition via Fusion (f3 = {f2 + f1}) -> violates Blackbox
 
-Composition via Asyncs (f3 => f1) -> violates Substitution (return of f3 is not return of f2)
+Composition via Asyncs (f3 => f1) -> violates Substitution (return of f3 is
+not return of f2)
 
 Composition via Reflection (f3 = f2 o f1) -> violates Double-billing
-
-
-
-
-
-

--- a/src/pages/scad/06-containerised.md
+++ b/src/pages/scad/06-containerised.md
@@ -17,85 +17,89 @@ tags:
 
 ## Source to Container
 
-Division of hardware resources by implementing many instances with isolation properties. 
+Division of hardware resources by implementing many instances with isolation properties.
 
 Standard image spec: Open Container Initiative (OCI)
 
 LXC
+
 - Linux specific, vendor neutral
 - boot from directory
 - namespacing of system resources in the Linux kernel
 - integrate with python lib
 
 Rocket
+
 - CoreOS / RedHat
 - book from AppC or Docker container image
 - namespacing of system resources as processes without daemon
 - integrate with systemd
 
 Docker
+
 - Docker Inc
 - boot from Docker container image
 - interpretation from Dockerfile
 - namespaceing of system resources as processes through central daemon
 - integrate with composition and computing tools (k8)
 
-
 ## Container Composition
 
 ### Docker Compose
 
 Describe with `docker-compose.yml` files
+
 - set of docker containers
 - build and run config
 - dependencies
 - instance details
-    - replicas
-    - restart policies
-    - placement
-    - networking
-    - volumes
-    
-   
-    version: '2.1
+  - replicas
+  - restart policies
+  - placement
+  - networking
+  - volumes
+
+```yaml
+    version: '2.1'
     services:
-        myservice
+      myservice:
         image: myimage
         restart: always
         depends_on:
-            myotherservice
+          - myotherservice
         environment:
-            VAR:value
+          - VAR=value
         ports:
-            80:443
+          - "80:443"
         logging:
-            optoins:
-                max-size: "10m"
-    
-Compose tools for log merging and command execution per instance.    
+          options:
+            max-size: "10m"
+```
 
-    docker-compose up
-    docker-compose down --volumes
+Compose tools for log merging and command execution per instance.
 
+```sh
+docker-compose up
+docker-compose down --volumes
+```
 
 ## Container Ecosystem
 
-Sites on which containerised service implementations are offered: Hubs, Stores, Exchanges, Marketplaces
+Sites on which containerised service implementations are offered: Hubs, Stores,
+Exchanges, Marketplaces
 
-
-    Containerised Application    
+```
+    Containerised Application
     ├── Monolithic
     ├── Microservices
     │   ├── Master-Slave
     │   ├── Nested-Container
-    
+```
 
-Related Processes Per Container (RPPC)
-
+Related Processes Per Container (`RPPC`)
 
 ### Container-Native Architecture
 
 Containers in VMs - simple but limited, more complex, single point of failures
 
 Cloud-native with data-center as a single Docker host, routing and discovery components
-

--- a/src/pages/scad/07-container-quality.md
+++ b/src/pages/scad/07-container-quality.md
@@ -5,7 +5,7 @@ date: "2020-01-05"
 draft: false
 author: Simon Anliker
 tags:
-  - scad
+- scad
 ---
 
 # Container Quality
@@ -13,6 +13,7 @@ tags:
 ## Docker Image Metadata
 
 On Docker Hub
+
 - Name
 - Stars
 - Publication date
@@ -23,60 +24,64 @@ On Docker Hub
 - Dates
 - Content
 - Image pull command
-- Hardware/OS-specific characteristics (platform/os)
-
+- Hardware/OS-specific characteristics (platform/OS)
 
 Docker Finder - multi attribute local search
 
-    dfinder java:1.7 --sort -size --sort +stars
-    
+```sh
+dfinder java:1.7 --sort -size --sort +stars
+```
 
 ## Docker Image Quality
 
 Dockerfile
+
 - invalid/faulting shell commands
 - invalid references to data sources for copy
 - too many layers / no command aggregation
 
 Docker image
+
 - deprecated/vulnerable code or shared libs
 - deprecated/vulnerable base image
 - inappropriate size
 
-
 Quality check tools: hadolint, dockerlint, anchore, dockscan
 
-
 Best practices for Dockerfiles
+
 - Pin version of used image explicitly
 - Use label for maintainer
 - Pin dependency versions explicitly
 - Concat run commands with \ where possible
 - Sort multi line arguments
-- Use COPY instead of ADD because it is more transparent (no additional functionality like tar extraction)
-- Use RUN with `wget` or `curl` instead of ADD so that unused files can be deleted to reduce image size (as part of the same RUN to not add any additional layers)
+- Use COPY instead of ADD because it is more transparent (no additional
+  functionality like tar extraction)
+- Use RUN with `wget` or `curl` instead of ADD so that unused files can be
+  deleted to reduce image size (as part of the same RUN to not add any
+  additional layers)
 - Use multi-stages builds
-- Use package trimming commands e.g. `--without-recommends` 
+- Use package trimming commands e.g. `--without-recommends`
 
 Best practices for builds
-- In most cases the Dockerfile should be in an empty directory, if not use `.dockerignore` (`docker build .` uses `.` as the context which is tar'd and sent to the docker daemon).
+
+- In most cases the Dockerfile should be in an empty directory, if not use
+  `.dockerignore` (`docker build .` uses `.` as the context which is tar'd
+  and sent to the docker daemon).
 - If no context is needed read from stdin: `docker build - < Dockerfile`
 - Design for "cattle"
 
-
 Strange stuff for files
+
 - One layer per file - high ops cost (tons of layers)
 - One layer per image - high storage cost (duplication)
 - All files in a single layer - high network cost (pull all, always)
 
 Wale: reduction of shared libraries by creating a core image with preprocessing
 
-DIVA: Docker image vulnerability analysis - find problems in base images, avoid vulnerability propagation
-
+DIVA: Docker image vulnerability analysis - find problems in base images, avoid
+vulnerability propagation
 
 ## Runtime Quality
 
 ChaosORCA architecture: fault injection at system call level
-
-
-

--- a/src/pages/scad/08-polytech-quality.md
+++ b/src/pages/scad/08-polytech-quality.md
@@ -5,7 +5,7 @@ date: "2020-01-05"
 draft: false
 author: Simon Anliker
 tags:
-  - scad
+- scad
 ---
 
 # Polytech Quality
@@ -13,14 +13,17 @@ tags:
 ## Polyglot/-tech Design
 
 Application modelling
+
 - TOSCA: Topology Orchestration Specification for Cloud Applications
 
 Enscapsulated application deployment
+
 - SAM: Serverless Application Model
 - CNAB: Cloud-Native Application Bundle
 - Helm charts
 
 Scripted application deployment
+
 - Imperative: Ansible, Chef, Heat
 - Declarative: Terraform, Puppet, Cloud Formation
 
@@ -28,4 +31,5 @@ Scripted application deployment
 
 Digital Artefact Observatory: Monitoring repositories
 
-Kubernetes Operators: lifecycle management of pods or complete applications, deployment, upgrades, dependencies, resource mapping for hybrid cloud
+Kubernetes Operators: lifecycle management of pods or complete applications,
+deployment, upgrades, dependencies, resource mapping for hybrid cloud

--- a/src/pages/scad/09-coud-native-dev.md
+++ b/src/pages/scad/09-coud-native-dev.md
@@ -5,7 +5,7 @@ date: "2020-01-05"
 draft: false
 author: Simon Anliker
 tags:
-  - scad
+- scad
 ---
 
 # Development for Clouds
@@ -13,6 +13,7 @@ tags:
 ## Approaches and Tools
 
 Conventional approach with separate dev and ops:
+
 - Long feedback cycles
 - Source-target incompatibilities
 - Slow upgrade of dev envs
@@ -21,16 +22,17 @@ Conventional approach with separate dev and ops:
 - Poor transaction support or complex deployments
 
 Development in and on the Cloud - shorten time to first dev cycle:
+
 - Always-online requirement alleviated with distributed sync (git)
 - Higher risk of vendor lock-in thus results may not be portable
-- Dev/ops separation of concerns lifted 
+- Dev/ops separation of concerns lifted
 
 New trends: Immutable infra, NoOps, DevSecOps, Web IDEs
-
 
 ## Models
 
 Service Description Languages
+
 - WSDL
 - WADL
 - USDL
@@ -44,10 +46,10 @@ Service Description Languages
 Top-down: generate code from description
 Bottom-up: generate description from code
 
-
 ## Publishing
 
 Bundle for deployment
+
 - Service implementation
 - Service description
 - Service configuration

--- a/src/pages/scad/10-dependencies.md
+++ b/src/pages/scad/10-dependencies.md
@@ -5,7 +5,7 @@ date: "2020-01-05"
 draft: false
 author: Simon Anliker
 tags:
-  - scad
+- scad
 ---
 
 # Service Dependencies
@@ -20,23 +20,28 @@ dependency B is depended on dependee A
 - strict vs tolerant
 
 Dependencies in software
+
 - code (executable)
 - configuration (declarative)
 - data (binary)
 
 Importance
+
 - if B goes down, A goes down too
 - hidden cost
 
 Dependency manifestation
+
 - tight coupling / fixed binding
 - loose coupling / late binding
 
 Dependency type
+
 - inter-service
 - intra-service (e.g. libs)
 
 Dependency consideration
+
 - transitivity (recursive algorithms)
 - data sources (DaaS model)
 - deployment (dependency affinity)
@@ -49,27 +54,29 @@ Dependency consideration
 
 Matrix structure for binary or qualified binary depends/not-depends relationship:
 
-      1 2 3 n  
-    1 .   .
-    2   . . .
-    3 .   . .
-    m       .
-    
- 
+```
+  1 2 3 n
+1 .   .
+2   . . .
+3 .   . .
+m       .
+```
+
 ### Graph
- 
+
 Associative graph structures: Directed acyclic, weighted or unweighted graph:
 
-    ServiceA -> ServiceB -> ServiceD
-                ServiceC -> 
-
+```
+ServiceA -> ServiceB -> ServiceD
+            ServiceC ->
+```
 
 Slower but more space-efficient than matrix and sub-structure capable.
 
-
-### Techniques
+### Dependency Resolution Techniques
 
 A depends on B if
+
 - declared as such
 - A invoked B (traceable)
 - logic of A depends on state withing B (non-traceable)
@@ -77,77 +84,85 @@ A depends on B if
 Analyse statically (description) or dynamically (execution).
 
 Dynamic analysis requires
+
 - correlation vs causation
 - small data sets
 - clustering of services
 
-
 #### Peddycord
 
-Passive network monitroing and analysis -> Network service dependency miner
+Passive network monitoring and analysis -> Network service dependency miner
 
 Logarithm based ranking scheme -> Ratio weight(A->B)/weight(A) or logarithm log(weight(A))*weight(A->B)
 
 Frequency inference -> confidence in dependency candidates
 
-
 ## Dependency resolution
 
 Immediate resolution
+
 - simple transitive inclusion
 - solution not guaranteed
 
 Interactive resolution
+
 - with feedback
 - iterative improvements
 - may complement immediate resolution upon escalation
 
-
 ## Composite services
 
-Offer a single service interface and distribute requests to multiple services within the composition (parallel, serial or more complex routing): requires knowledge of dependencies.
+Offer a single service interface and distribute requests to multiple services
+within the composition (parallel, serial or more complex routing): requires
+knowledge of dependencies.
 
 Advantages of services
+
 - higher availability (QoService)
 - flexibility to switch (QoExperience)
 
 ### Techniques
 
 Service Orchestration
+
 - Multiple services form another one
 - Centrally managed and executed
 - Based on workflows that require service interfaces
 - Examples:
-    - Business Process Execution Language (BPEL)
-    - Yet Another Workflow Language (YAWL)
-    - Dynamic Service Orchestration Language (DSOL)
-    - AWS Step Functions
+  - Business Process Execution Language (BPEL)
+  - Yet Another Workflow Language (YAWL)
+  - Dynamic Service Orchestration Language (DSOL)
+  - AWS Step Functions
 
 Resource Orchestration
+
 - Workflows require resources
 - Resource allocation performed centrally
 - Examples:
-    - Heat Orchestration Template (HOT)
-    - Docker Compose
-    - Kubernetes Descriptors
+  - Heat Orchestration Template (HOT)
+  - Docker Compose
+  - Kubernetes Descriptors
 
 Choreography
+
 - Interaction protocol between autonomous services
 - No central point of control
 - Difficult decentralised enactment
 - Example:
-    - BPMN 2.0
-    - Chor
-    - CHOReVOLUTION
+  - BPMN 2.0
+  - Chor
+  - CHOReVOLUTION
 
 Bundling
+
 - Multiple services used in a bundle
 - Less administrative overhead
 - Less flexibility for exchanging single services
 - Example:
-    - USDL
-    
+  - USDL
+
 Multiplexing
+
 - Multiple services used in parallel handling partial requests
 - Flexible redundancy systems
 - More administrative overhead
@@ -156,25 +171,18 @@ Multiplexing
 Mashup
 Service Bus/Mash
 
- 
 ## Artefacts
 
 Bundles: WAR, SAR, BPR, ZIP, Helm charts
 
-Executable code: .class, .py
+Executable code: `.class`, `.py`
 
 Service descriptions: WSDL, ...
 
 SLA templates: WSLA, WS-Agreement
 
-Deployment descriptors: HOT, PDD, web.xml, k8 yaml/json, Help templates
-
+Deployment descriptors: HOT, PDD, web.xml, k8s yaml/json, Help templates
 
 Dependencies by reference (e.g. Docker Compose): need resolution before execution
 
 Dependencies by embedding (e.g. Helm charts): no resolution needed but transitivity
-
-
-
-
-

--- a/src/pages/scad/11-scalable-apps.md
+++ b/src/pages/scad/11-scalable-apps.md
@@ -5,13 +5,13 @@ date: "2020-01-18"
 draft: false
 author: Simon Anliker
 tags:
-  - scad
+- scad
 ---
 
 # Scalable Cloud Application
 
-
 Cloud-Native Application (CNA): Fully exploiting cloud services and platform features
+
 - elastic scalability
 - resilience
 - confidentiality
@@ -25,41 +25,50 @@ Adapt to demand
 Manual- vs. auto- vs. prescaling
 
 Properties
+
 - Elasticity (time): degree of adaption
 - Transformativity (space/behaviour): self-similarity, bottlenecks
 - Boundedness (space): upper/lower bounds
 
 Mismatches
+
 - Billing cycle
 - Memory allocation
 - Dynamic profile
 
 Scaling for app packages/functions
+
 - Indirect through runtime
 - Configurable
 
-Vertical Scaling 
+Vertical Scaling
+
 - Hypervisor memory (e.g. KVM `setmem <xG> --live`)
 - Hypervisor processor (e.g. `cpu_set <n+1> online`, DVFS tuning)
 
 Vertical Scaling for Containers
+
 - Static resource limits (Docker, Kubernetes descriptors)
 - ElasticDocker: Feedback loop for memory + CPU assignment (MAPE-K)
 
-Horizontal Scaling 
+Horizontal Scaling
+
 - Parallel, single host: Multiple processes and threads, limited by # CPU cores
-- Distributed, multiple hosts: Multiple instances over the network, limited by # nodes.
+- Distributed, multiple hosts: Multiple instances over the network, limited by
+  number of nodes.
 
 Horizontal Scaling for Containers
+
 - Amdahl's law: Decreasing effectiveness of scaling factor
 - Optimal scale detection: Beforehand (prescaling) vs later (costly)
-- Optimality: Determine sweetspots (minimum cost , minimum makespan -> minimum weighted utility)
-
+- Optimality: Determine sweetspots (minimum cost , minimum makespan -> minimum
+  weighted utility)
 
 Diagonal Scaling
-- Solution to issue in public clouds for limited granularity x slow scaling speeds x flat pricing schemes
-- Increase in savings vs application loading
 
+- Solution to issue in public clouds for limited granularity x slow scaling
+  speeds x flat pricing schemes
+- Increase in savings vs application loading
 
 ## Autoscaling
 
@@ -68,20 +77,22 @@ Diagonal Scaling
 - More instances/replication for horizontal scaling
 
 Taxonomy: Autoscaling
+
 - reactive
-    - app--agnostic
-    - app-specific
+  - app--agnostic
+  - app-specific
 - proactive
-    - app-specific
+  - app-specific
 
 Reactive
+
 - chaotic over-/underprovisioning
 - risk of SLA violation
 
 Proactive
+
 - controlled
 - SLAs maintained
-
 
 ### Prediction
 
@@ -93,57 +104,65 @@ ARMA: Combined AR/MA
 
 Polynomial & Spline Interpolation
 
-Time series data -> _predictor_ -> user prediction -> _resource planner_ -> resource demand -> _action plan generator_ -> action plan for scaling
+Time series data -> _predictor_ -> user prediction -> _resource planner_ ->
+resource demand -> _action plan generator_ -> action plan for scaling
 
 Predictors (users/time)
-- Baseline: Use current value
-- Nearest neighbor: Look back to nearest neighbor bit same value and repeat pattern for the given timeframe
-- Lagged neighbor: Look back to lagged neighbor defined by a period and repeat pattern for given timeframe
 
+- Baseline: Use current value
+- Nearest neighbor: Look back to nearest neighbor bit same value and repeat pattern
+  for the given timeframe
+- Lagged neighbor: Look back to lagged neighbor defined by a period and repeat
+  pattern for given timeframe
 
 ## Scalable App Design
 
 ### Multi-Tier
 
 Characteristics
+
 - Popular for web apps and client-server
 - 3-tier: frontend, backend, DB
 - 4-tier: client/frontend, delivery, aggregation/logic, services
 
 Advantages
+
 - Simple monolithic blocks
 - Established standards for protocols
 - Sufficient flexibility for complementary blocks
 
 Disadvantages
+
 - Inequal loads and bottlenecks
 - Only applicable in isolated applications
-
 
 ### Service-oriented
 
 Characteristics
+
 - Service orientation
-    - Uniform description
-    - Communication
-    - Encapsulation
-    - Reuse
+  - Uniform description
+  - Communication
+  - Encapsulation
+  - Reuse
 - Discovery
 - Flexible dynamic bindings
 
 Advantages
+
 - Consequent evolution of complex software design
 - Viable basis for rapid prototyping of services
 
 Disadvantages
+
 - Waning support for classical SOA technologies
 - No guidance for how to design, build, run services
-
 
 ### Cloud-native
 
 Characteristics
-- Scalability 
+
+- Scalability
 - Resilience
 - Refines service orientation with microservices
 - Exploits capabilities of cloud environments
@@ -151,21 +170,23 @@ Characteristics
 - DBaaS
 
 Advantages
+
 - Closest to ideal scalability
 - Elastic, hardly bounded/transformative
 - Matched by contemporary technologies
 - Conversion of legacy applications possible
 
 Disadvantages
+
 - Technological immaturity and volatility
 - Emerging tools and languages
 - Incompatibilities
 - Insufficiencies
 
-
 ### Messaging
 
 Diverse types of messaging systems
+
 - Message queues
 - Message brokers
 - Stream processing
@@ -175,27 +196,28 @@ Diverse types of messaging systems
 - Microservice mesh
 - with billing by # messages, payload size, mgmt calls
 
-
 #### Kafka
 
 - Sharding + threading: Inverse of Amdahl's law
 - High availability if partition replias are on different fault and update domain.
 
-
 ### Coordination
 
 Consensus, voting, leader election, synchrony
+
 - Coordination faults
 - Byzantine faults/attacks
 
-Majorities
-- None 
+#### Majorities
+
+- None
 - Relative (n > m for all n,m in N)
 - Absolute (n > N/2)
 - Byzantine (n > 2N/3)
 - Consensus (n == N)
 
-Paxos Consensus
+#### Paxos Consensus
+
 - Requires absolute majority
 - Extension: Byzantine Paxos
 - Roles: Voters/acceptors, learners, proposers, leader
@@ -205,37 +227,43 @@ Paxos Consensus
 - Depends on redundancy
 - Ignores failures of redundant participants
 
-Swedish Leader Election
+#### Swedish Leader Election
+
 - Based on rounds of elimination of candidates
 - Flop coin - winner proceed into next round, otherwise play again
 - Last remaining candidate is leader
 - Good characteristics
 
-Raft
+#### Raft
+
 - Recent, modular algorithm
 - Uses log replication
 - Random timeout for followers -> become candidates
 - Absolute majority of votes -> leader
 - Heartbeats define election term
 
-Implementations
-- Zookeeper: Zab algorithm (Zookeeper atomic broadcast), similar to Paxos but with stricter ordering guarantees
+#### Implementations
+
+- Zookeeper: Zab algorithm (Zookeeper atomic broadcast), similar to Paxos but
+  with stricter ordering guarantees
 - Etcd/Consul: Distributed service discovery and configuration with Raft
 - Microsoft Distributed Mutex (C#): Leader election, custom algorithm
 
 CAP theorem: focus on CA microservices
 
-BAC theorem: when backing up microservices, it it not possible to have both availability and consistency
+BAC theorem: when backing up microservices, it it not possible to have both
+availability and consistency
 
 Summary
+
 - Coordination, data distribution, autoscaling
 - Self-* characteristics
 - Cloud-native components
 
-
 ### Distributed Microservice Scalability
 
 Performance benchmark
+
 - Performance must remain high
 - Not entirely linear (Amdahls law)
 - FaaS 1:1 event:instance
@@ -243,20 +271,26 @@ Performance benchmark
 
 OpenShift / APPUiO
 
-    oc scale --replicas=3 dc app
-    oc autoscale app --min 1 --max 10 --cpu-percent=80
-    
+```sh
+oc scale --replicas=3 dc app
+oc autoscale app --min 1 --max 10 --cpu-percent=80
+```
 
 IBM Cloud
 
-    cf aasp app policy.json
-    
+```sh
+cf aasp app policy.json
+```
 
 GCP
 
-    gcloud compute instance-groups managed set-autoscaling app-igroup --max-num-replicas 10 -target-cpu-utilization 0.92 --cool-down-period 30
-    
-    
+```sh
+gcloud compute instance-groups managed set-autoscaling app-igroup \
+    --max-num-replicas 10 \
+    -target-cpu-utilization 0.92 \
+    --cool-down-period 30
+```
+
 ### Fallacies
 
 - The network is reliable: App needs error handling and retry

--- a/src/pages/scad/12-resilient-apps.md
+++ b/src/pages/scad/12-resilient-apps.md
@@ -5,12 +5,13 @@ date: "2020-01-19"
 draft: false
 author: Simon Anliker
 tags:
-  - scad
+- scad
 ---
 
 # Resilient Cloud Application
 
 Service Lifecycle
+
 - Service Offering: Implementation, Description, Registration
 - Service Discovery: Request, Matchmaking, Negotiation
 - Service Usage: Activation, Monitoring, Optimization
@@ -19,6 +20,7 @@ Service Lifecycle
 ## Quality dimensions
 
 SQuaRE (Software product Quality Requirements and Evaluation - ISO/IEC 25000)
+
 - Functional suitability
 - Performance efficiency
 - Compatibility
@@ -28,23 +30,32 @@ SQuaRE (Software product Quality Requirements and Evaluation - ISO/IEC 25000)
 - Security
 - Portability
 
+Formula:
+_Reliability = Maturity + Availability + Fault tolerance + Recoverability + Compliance_
 
-Reliability = Maturity + Availability + Fault tolerance + Recoverability + Compliance
+### Reliability (IEEE)
 
-Reliability (IEEE): The portability of failure-free software operation for a specified period of time in a specified environment
+The portability of failure-free software operation for a specified period of
+time in a specified environment.
 
-Resiliency: The ability of an app to recover from certain types of failure and yet remain functional from the customer perspective
+### Resiliency
 
-Service Quality Model: Non-functional characteristics (performance, cost, compliance to standards), QoS
+The ability of an app to recover from certain types of failure and yet remain
+functional from the customer perspective.
 
+### Service Quality Model
+
+Non-functional characteristics (performance, cost, compliance to standards), QoS
 
 Quality specifications
+
 - UML with OCL (Object Constraint Language)
 - CQML+ (Component Quality Modelling Language)
 - OASIS/TOSCA
 - SLA (Service Level Agreement) as languages (LegalXML, XACML, WSAG, WSLA, SLAng)
 
 Quality dimensions
+
 - Relevance
 - Added value
 - Confidence
@@ -60,39 +71,45 @@ Functionality: what a service is doing
 Non-functional property: How a service is doing what it is doing
 
 Measurable quality
+
 - Described metrics: Authoritative vs. non-authoritative
 - Measured metrics: Monitoring, attestation services
 - Estimated metrics: Prediction algorithms
 - Static analysis: Descriptions (completeness, timeliness)
 - Dynamic analysis: Measurements (correctness)
 
-Servie metaquality (SMQ): how well is a service described
+Service metaquality (SMQ): how well is a service described
 
-SQM caclulation and decision: Table with quality dimensions and NFPs - weighted quality dimension per metric
-
+SQM caclulation and decision: Table with quality dimensions and NFPs - weighted
+quality dimension per metric
 
 ## Replication
 
 Replica: Repeated software component or data
+
 - Faster response time through multiplexing
 - Improved safety through backup
 - Increased storage/computation/bandwidth
 
 Taxonomy
+
 - partial (decomposed/erasures)
 - full (n-fold)
 
 Placement
-- Equal distribution 
+
+- Equal distribution
 - Proportional distribution
 - Absolute distribution
 
 Optimal algorithm
+
 - Staggered determination
 - Guarantee of availability, price, capacity
 - Deadline for calculation
 
 Data
+
 - Singular copies
 - Incremental copies, backup with deltas, Hanoi strategy
 - Distributed versioned replication
@@ -101,62 +118,67 @@ Data
 ### Erasure coding
 
 c = a XOR b
+
 - if a fails, recover a = c XOR b
 - if b fails, recover b = c XOR a
 - if c fails, recalc  c = a XOR b
 - 50% redundancy (2 significant, 1 redundant)
 
 d = a XOR b XOR c
+
 - 33% redundancy (3 significant, 1 redundant)
 
 z = erasure(a,b,...) in Galois Field GF(2)
-- arbitrary redundancy
 
+- arbitrary redundancy
 
 ## Resilience
 
 ### Fault injection
 
-Test before releases, find issues -> 
+Test before releases, find issues ->
 Chaos engineering, live system, simulation/emulation
 
 Software level
+
 - Fuzzing: Invalid data input
 - Data modifications
 - e.g. jFuzz concolic whitebox fuzzer
 
 System level
+
 - Resource exhaustion
 - Limits exhaustion
 - Random process signaling/termination
 - e.g. Chaosmonkey
 
 Network level
+
 - Artificial slowdown
 - Random port blocking
 - Protocol mutation
 - e.g. Chaosmonkey
-    
 
 #### Emulation
 
-MC-EMU: Multi cloud emulator 
+MC-EMU: Multi cloud emulator
 
 Behavioural models
+
 - convergence
 - incident
 - random
 - replay/library
 
 Properties
+
 - availability
 - slowness
 - popularity
 
 Targets
+
 - No-op
 - Web/file server (storage)
 - OS container (compute)
 - L4 proxy (network)
-
-

--- a/src/pages/scad/13-app-domains-patterns.md
+++ b/src/pages/scad/13-app-domains-patterns.md
@@ -5,49 +5,57 @@ date: "2020-01-19"
 draft: false
 author: Simon Anliker
 tags:
-  - scad
+- scad
 ---
 
 # Application Domains and Patterns
 
 ## Service domains
 
-Robotic services 
+Robotic services
+
 - Device constraints, lifecycles, messaging models
 - Platform and runtime differences
 - Non-standardised integration of cloud and non-cloud parts
 
 Mobile service
+
 - Sweetspot through controlled mobile -> coud offloading
 - Increasing support by cloud providers
 
 Multimedia services
-- Long history of standardisation including complex communication patterns such as sessions or broadcast
-- Limited but increasing support by cloud providers
 
+- Long history of standardisation including complex communication patterns such
+  as sessions or broadcast
+- Limited but increasing support by cloud providers
 
 ## Microservices and container patterns
 
 1-Node, 1-Container
+
 - Upward: metrics, profiling
 - Downward: lifecycle adherence
-- Containers: resource accounting and allocation, packaging, deployment, reuse, failure containment boundary
+- Containers: resource accounting and allocation, packaging, deployment, reuse,
+  failure containment boundary
 
 1-Node, n-Containers
+
 - Sidecar
-    - Pickup car: Log transportation
-    - Parcel car: Serving sync content
-    - ACS car: Repair
-    - Toll car: Service discovery
+  - Pickup car: Log transportation
+  - Parcel car: Serving sync content
+  - ACS car: Repair
+  - Toll car: Service discovery
 - Ambassador: proxy and represent
 - Adapter: normalise and present
 
 m-Nodes, n-Containers
+
 - Leader election: voting and determining leader
 - Work queue: coordinator and grabbers
 - Scatter/gather: distribution of requests
 
 Operator pattern
+
 - Container managing aspects of other containers (extension of sidecar)
 - Commission, decommission, upgrade, downgrade, configure, coordination, backup
 - e.g. Kubernetes operator framework


### PR DESCRIPTION
This commit lints all markdown files according to the default rules that
markdownlinter ([mdl](https://github.com/markdownlint/markdownlint)) uses.

There is one exception, which I could not eliminate: The header "tags" list.
But the header is not parsed directly anyway, so I think we can live
with it.

To name the most common issues:
- no newline before a list
- code indented instead of backticks (I don't think it's a rule in `mdl`, but support for backticks is better)
- Indentation for lists 
- Line length

i also fixed a few typos that I've stumbled upon.

Signed-off-by: Ramon Rüttimann <me@ramonr.ch>